### PR TITLE
Update FC and GML schema 1.2.0

### DIFF
--- a/1.2.0/FC/S-129_1_2_0_FC.XML
+++ b/1.2.0/FC/S-129_1_2_0_FC.XML
@@ -1,0 +1,358 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<S100FC:S100_FC_FeatureCatalogue 
+  xmlns:S100FC="http://www.iho.int/S100FC/5.0" 
+  xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+  xmlns:S100CI="http://www.iho.int/S100CI/5.0"
+  xmlns:S100CD="http://www.iho.int/S100CD/5.0"
+  xmlns:xlink="https://schemas.s100dev.net/schemas/S100/5.0.0/w3c/XML/2008/06/xlink.xsd"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="1.2.0-20240426">
+
+  <S100FC:name>Feature Catalogue for S-129</S100FC:name>
+  <S100FC:scope>Dynamic under keel clearance management information</S100FC:scope>
+  <S100FC:fieldOfApplication>Under keel clearance management</S100FC:fieldOfApplication>
+  <S100FC:versionNumber>1.2.0</S100FC:versionNumber>
+  <S100FC:versionDate>20240426</S100FC:versionDate>
+    <S100FC:productId>S-129</S100FC:productId>
+  <S100FC:producer>
+    <S100CI:role>editor</S100CI:role>
+    <S100CI:party>
+      <S100CI:CI_Organisation>
+        <S100CI:name>KMOU</S100CI:name>
+        <S100CI:contactInfo>
+          <S100CI:address>
+            <S100CI:administrativeArea>727 Taejong-ro, Yeongdo-Gu, Busan 49112</S100CI:administrativeArea>
+            <S100CI:country>Republic of Korea</S100CI:country>
+            <S100CI:electronicMailAddress>sjlee@kmou.ac.kr</S100CI:electronicMailAddress>
+          </S100CI:address>
+          <S100CI:onlineResource>
+            <S100CI:linkage>www.kmou.ac.kr</S100CI:linkage>
+          </S100CI:onlineResource>
+        </S100CI:contactInfo>
+      </S100CI:CI_Organisation>
+    </S100CI:party>
+  </S100FC:producer>
+
+  <S100FC:S100_FC_SimpleAttributes>
+    <!--attributes-->
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Generation Time</S100FC:name>
+      <S100FC:definition>Time the UKC plan was generated.</S100FC:definition>
+      <S100FC:code>generationTime</S100FC:code>
+      <S100FC:valueType>dateTime</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Vessel ID</S100FC:name>
+      <S100FC:definition>Vessel identifier, based on MRN. Can be either IMO or MMSI based.</S100FC:definition>
+      <S100FC:code>vesselID</S100FC:code>
+      <S100FC:valueType>text</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Source Route Name</S100FC:name>
+      <S100FC:definition>Identification of the route used as a source for the calculation.</S100FC:definition>
+      <S100FC:code>sourceRouteName</S100FC:code>
+	  <S100FC:remark>Using the value of S-421.Route.routeInfoName.</S100FC:remark>
+      <S100FC:valueType>text</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Source Route Version</S100FC:name>
+      <S100FC:definition>Identification of the route used as a source for the calculation.</S100FC:definition>
+      <S100FC:code>sourceRouteVersion</S100FC:code>
+	  <S100FC:remark>Using the value of S-421.RouteHistory.routeHistoryEditionNo.</S100FC:remark>
+      <S100FC:valueType>text</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Maximum Draught</S100FC:name>
+      <S100FC:definition>The maximum ship draught in metres, used as base for the calculation.</S100FC:definition>
+      <S100FC:code>maximumDraught</S100FC:code>
+      <S100FC:valueType>real</S100FC:valueType>
+	  <S100FC:uom>
+		<S100Base:name>metres</S100Base:name>
+		<S100Base:symbol>m</S100Base:symbol>
+	  </S100FC:uom>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Scale Minimum</S100FC:name>
+      <S100FC:definition>The minimum scale at which the object may be used, e.g., for ECDIS presentation.</S100FC:definition>
+      <S100FC:code>scaleMinimum</S100FC:code>
+      <S100FC:remarks>The modulus of the scale is indicated, that is 1:1 250 000 is encoded as 1250000.</S100FC:remarks>
+      <S100FC:alias>SCAMIN</S100FC:alias>
+      <S100FC:valueType>integer</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Name</S100FC:name>
+      <S100FC:definition>The individual name of a feature.</S100FC:definition>
+      <S100FC:code>name</S100FC:code>
+      <S100FC:valueType>text</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Expected Passing Time</S100FC:name>
+      <S100FC:definition>The expected passing time for a ship for a nominated Under Keel Clearance Control Point.</S100FC:definition>
+      <S100FC:code>expectedPassingTime</S100FC:code>
+      <S100FC:valueType>dateTime</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Expected Passing Speed</S100FC:name>
+      <S100FC:definition>The expected passing speed for a ship for a nominated Under Keel Clearance Control Point.</S100FC:definition>
+      <S100FC:code>expectedPassingSpeed</S100FC:code>
+      <S100FC:valueType>real</S100FC:valueType>
+	  <S100FC:uom>
+		<S100Base:name>metres per seconds</S100Base:name>
+		<S100Base:symbol>m/s</S100Base:symbol>
+	  </S100FC:uom>	  
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Time Start</S100FC:name>
+      <S100FC:definition>The start time of an active period.</S100FC:definition>
+      <S100FC:code>timeStart</S100FC:code>
+      <S100FC:valueType>dateTime</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Time End</S100FC:name>
+      <S100FC:definition>The end time of an active period.</S100FC:definition>
+      <S100FC:code>timeEnd</S100FC:code>
+      <S100FC:valueType>dateTime</S100FC:valueType>
+    </S100FC:S100_FC_SimpleAttribute>
+	  <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Distance Above UKC Limit</S100FC:name>
+      <S100FC:definition>The distance of the lowest part of the ship's keel above the established Under Keel Clearance Limit for the waterway, expressed in metres.</S100FC:definition>
+      <S100FC:code>distanceAboveUKCLimit</S100FC:code>
+      <S100FC:valueType>real</S100FC:valueType>
+	  <S100FC:uom>
+		<S100Base:name>metres</S100Base:name>
+		<S100Base:symbol>m</S100Base:symbol>
+	  </S100FC:uom>
+    </S100FC:S100_FC_SimpleAttribute>
+	
+    <!--attributes - enumeration-->
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Under Keel Clearance Purpose</S100FC:name>
+      <S100FC:definition>The relevant phase of a UKC passage plan.</S100FC:definition>
+      <S100FC:code>underKeelClearancePurpose</S100FC:code> 
+      <S100FC:remarks>remarks</S100FC:remarks>      
+      <S100FC:valueType>enumeration</S100FC:valueType>
+      <S100FC:listedValues>
+        <S100FC:listedValue>
+          <S100FC:label>prePlan</S100FC:label>
+          <S100FC:definition></S100FC:definition>
+          <S100FC:code>1</S100FC:code>
+        </S100FC:listedValue>
+        <S100FC:listedValue>
+          <S100FC:label>actualPlan</S100FC:label>
+          <S100FC:definition></S100FC:definition>
+          <S100FC:code>2</S100FC:code>
+        </S100FC:listedValue>
+        <S100FC:listedValue>
+          <S100FC:label>actualUpdate</S100FC:label>
+          <S100FC:definition></S100FC:definition>
+          <S100FC:code>3</S100FC:code>
+        </S100FC:listedValue>
+      </S100FC:listedValues>      
+    </S100FC:S100_FC_SimpleAttribute>
+
+    <S100FC:S100_FC_SimpleAttribute>
+      <S100FC:name>Under Keel Clearance Calculation Requested</S100FC:name>
+      <S100FC:definition>Indication of how the plan was calculated.</S100FC:definition>
+      <S100FC:code>underKeelClearanceCalculationRequested</S100FC:code>
+      <S100FC:remarks>remarks</S100FC:remarks>
+      <S100FC:valueType>enumeration</S100FC:valueType>
+      <S100FC:listedValues>
+        <S100FC:listedValue>
+          <S100FC:label>timeWindow</S100FC:label>
+          <S100FC:definition></S100FC:definition>
+          <S100FC:code>1</S100FC:code>
+        </S100FC:listedValue>
+        <S100FC:listedValue>
+          <S100FC:label>maxDraught</S100FC:label>
+          <S100FC:definition></S100FC:definition>
+          <S100FC:code>2</S100FC:code>
+        </S100FC:listedValue>
+      </S100FC:listedValues>
+    </S100FC:S100_FC_SimpleAttribute>        
+  </S100FC:S100_FC_SimpleAttributes>
+
+  <!--attributes - complexAttribute-->
+  <S100FC:S100_FC_ComplexAttributes>
+    <S100FC:S100_FC_ComplexAttribute>
+      <S100FC:name>Fixed Time Range</S100FC:name>
+      <S100FC:definition>Time interval.</S100FC:definition>
+      <S100FC:code>fixedTimeRange</S100FC:code>
+      <S100FC:subAttributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="timeStart"/>        
+      </S100FC:subAttributeBinding>
+      <S100FC:subAttributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="timeEnd"/>
+      </S100FC:subAttributeBinding>
+    </S100FC:S100_FC_ComplexAttribute>
+  </S100FC:S100_FC_ComplexAttributes>
+
+  <!--features-->
+  <S100FC:S100_FC_FeatureTypes>
+    <S100FC:S100_FC_FeatureType>
+      <S100FC:name>Under Keel Clearance Plan</S100FC:name>
+      <S100FC:definition>This feature is MetaFeature of UKCM information</S100FC:definition>
+      <S100FC:code>underKeelClearancePlan</S100FC:code>
+      <S100FC:remarks></S100FC:remarks>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="fixedTimeRange"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="generationTime"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="vesselID"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="sourceRouteName"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="sourceRouteVersion"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="maximumDraught"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:permittedValues>
+          <S100FC:value>1</S100FC:value>
+          <S100FC:value>2</S100FC:value>
+          <S100FC:value>3</S100FC:value>
+        </S100FC:permittedValues>
+        <S100FC:attribute ref="underKeelClearancePurpose"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:permittedValues>
+          <S100FC:value>1</S100FC:value>
+          <S100FC:value>2</S100FC:value>          
+        </S100FC:permittedValues>
+        <S100FC:attribute ref="underKeelClearanceCalculationRequested"/>
+      </S100FC:attributeBinding>
+      <S100FC:featureUseType>meta</S100FC:featureUseType>
+      <S100FC:permittedPrimitives>surface</S100FC:permittedPrimitives>
+    </S100FC:S100_FC_FeatureType>
+
+    <S100FC:S100_FC_FeatureType>
+      <S100FC:name>Under Keel Clearance Non Navigable Area</S100FC:name>
+      <S100FC:definition>Non Navigation Area</S100FC:definition>
+      <S100FC:code>underKeelClearanceNonNavigableArea</S100FC:code>
+      <S100FC:remarks></S100FC:remarks>
+	  <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="scaleMinimum"/>
+      </S100FC:attributeBinding>
+      <S100FC:featureUseType>geographic</S100FC:featureUseType>
+      <S100FC:permittedPrimitives>surface</S100FC:permittedPrimitives>
+    </S100FC:S100_FC_FeatureType>
+
+    <S100FC:S100_FC_FeatureType>
+      <S100FC:name>Under Keel Clearance Almost Non Navigable Area</S100FC:name>
+      <S100FC:definition>Almost Non Navigable Area</S100FC:definition>
+      <S100FC:code>underKeelClearanceAlmostNonNavigableArea</S100FC:code>
+      <S100FC:remarks></S100FC:remarks>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="scaleMinimum"/>
+      </S100FC:attributeBinding>
+	  <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="distanceAboveUKCLimit"/>
+      </S100FC:attributeBinding>
+      <S100FC:featureUseType>geographic</S100FC:featureUseType>
+      <S100FC:permittedPrimitives>surface</S100FC:permittedPrimitives>
+    </S100FC:S100_FC_FeatureType>
+
+    <S100FC:S100_FC_FeatureType>
+      <S100FC:name>Under Keel Clearance Control Point</S100FC:name>
+      <S100FC:definition>UnderKeelClearance ControlPoint</S100FC:definition>
+      <S100FC:code>underKeelClearanceControlPoint</S100FC:code>
+      <S100FC:remarks></S100FC:remarks>
+	  <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="name"/>
+      </S100FC:attributeBinding>
+	  <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="expectedPassingTime"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="expectedPassingSpeed"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="distanceAboveUKCLimit"/>
+      </S100FC:attributeBinding>
+      <S100FC:attributeBinding sequential="false">
+        <S100FC:multiplicity>
+          <S100Base:lower>0</S100Base:lower>
+          <S100Base:upper xsi:nil="false" infinite="false">1</S100Base:upper>
+        </S100FC:multiplicity>
+        <S100FC:attribute ref="fixedTimeRange"/>
+      </S100FC:attributeBinding>    
+      <S100FC:featureUseType>geographic</S100FC:featureUseType> 
+      <S100FC:permittedPrimitives>point</S100FC:permittedPrimitives>
+    </S100FC:S100_FC_FeatureType>
+  </S100FC:S100_FC_FeatureTypes>  
+
+</S100FC:S100_FC_FeatureCatalogue>

--- a/1.2.0/FC/S100/S100Base.xsd
+++ b/1.2.0/FC/S100/S100Base.xsd
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © Copyright 2011, 2014-2016, 2022 International Hydrographic Organisation 
+License (Draft)
+Certain parts of this document refer to or are based on the standards, documents, schemas,
+or other material of the International Organization for Standardization (ISO), Open Geospatial
+Consortium (OGC), International Hydrographic Organization / Organisation Hydrographique
+Internationale (IHO/OHI).
+The ISO material can be obtained from any ISO member and from the Web site of the ISO Central
+Secretariat at www.iso.org.
+The OGC material can be obtained from the OGC Web site at www.opengeospatial.org.
+The IHO material can be obtained from the IHO Web site at www.iho.int or from the International
+Hydrographic Organization Secretariat.
+
+Permission to copy and distribute this document is hereby granted provided that this notice is
+retained on all copies, and that the IHO is credited when the material is redistributed
+or used in part or whole in derivative works.
+Redistributions in binary form must reproduce this notice in the documentation and/or other
+materials provided with the distribution.
+
+Disclaimer
+This work is provided by the copyright holders and contributors "as is" and any express or implied
+warranties, including, but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be
+liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including,
+but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or
+business interruption) however caused and on any theory of liability, whether in contract, strict
+liability, or tort (including negligence or otherwise) arising in any way out of the use of this
+software, even if advised of the possibility of such damage.
+-->
+<!-- Date: 04 September 2014; Modification: Updated for S-100 Ed. 2.0.0 -->
+<!-- Date: 16 September 2014; Modification: added schema version; -->
+<!-- 2015-09-21 Raphael Malyankar Added S100_ prefix and replaced intervaltype with
+     closure in S100_NumericRange to conform names to S-100 edition 2.0.0;
+     2016-07-15: Updated copyright/license statement
+     Note: This should be updated to use the ISO schemas or a profile of them wherever S-100 is using the ISO type
+  2018-05-02 (Raphael Malyankar): Edition 4.0: CharacterSetCode19115_3 enumeration added with IANA codes in
+    accordance with 19115-3. The old CharacterSet is still used pending coordination of future updates to
+    the feature catalogue model and FCB for compatibility with ISO 19115-3.
+  S-100 Edition 5 Build 20220331: Language and country code removed, they are not being used in the FC after removing
+    the classes defined for Part 2/2a/2b but not used in the FC.
+    To do: Resolve discrepancy in S100_NumericRange as defined here and in Part 1 (S-100 proposal reguired?) then replace with
+    S100CSL.xsd from Part 1
+    Build 20220610: build number in version updated due to update in S100 FC XSD
+-->
+  <!-- Prepared for the International Hydrographic Organisation (IHO).
+    Contributors: Holger Bothien (SevenCs/Chartworld); Tom Richardson (UKHO); Sewoong Oh (KRISO);
+    Yong Baek (KHOA); Raphael Malyankar (Jeppesen); Raphael Malyankar (Portolan Sciences LLC
+  -->
+<xs:schema targetNamespace="http://www.iho.int/S100Base/5.0" elementFormDefault="qualified" 
+           xmlns="http://www.iho.int/S100Base/5.0" 
+           xmlns:mstns="http://www.iho.int/S100Base/5.0" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" version="5.0.0-20220610">
+  <xs:complexType name="UnlimitedInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:attribute name="infinite" type="xs:boolean" default="false" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="S100_Multiplicity">
+    <xs:sequence>
+      <xs:element name="lower" type="xs:nonNegativeInteger" />
+      <xs:element name="upper" type="UnlimitedInteger" nillable="true" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="S100_IntervalType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="openInterval" />
+      <xs:enumeration value="geLtInterval" />
+      <xs:enumeration value="gtLeInterval" />
+      <xs:enumeration value="closedInterval" />
+      <xs:enumeration value="gtSemiInterval" />
+      <xs:enumeration value="geSemiInterval" />
+      <xs:enumeration value="ltSemiInterval" />
+      <xs:enumeration value="leSemiInterval" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Note the discrepancy between this and S100_NumericRange in S100CSL. To be resolved by an S-100 proposal? -->
+  <xs:complexType name="S100_NumericRange">
+    <xs:sequence>
+      <xs:element name="lowerBound" type="xs:double" maxOccurs="1" minOccurs="0" />
+      <xs:element name="upperBound" type="xs:double" maxOccurs="1" minOccurs="0" />
+      <xs:element name="closure" type="S100_IntervalType" maxOccurs="1" minOccurs="1" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <!--<xs:simpleType name="CharacterSet19115_3">
+    <xs:annotation>
+      <xs:documentation>(ISO 19115-1 B.3.14 MD_CharacterSetCode) Use IANA Character Set register: http://www.iana.org/assignments/character‐sets. This enumeration is a subset of the full IALA register, selected on the basis of equivalency to the list in previous versions of this file and likelihood of use.</xs:documentation>
+      <xs:documentation>Updated for 5.0.0 to allow only UTF-8. This list is deprecated - the codelist in the S-100 resources folder should be preferred.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+
+<!-\-      <xs:enumeration value="ISO-10646-UCS-2" />
+      <xs:enumeration value="ISO-10646-UCS-4" />
+      <xs:enumeration value="ISO-10646-UCS-Basic"/>
+      <xs:enumeration value="ISO-10646-Unicode-Latin1"/>
+      <xs:enumeration value="ISO-10646-Unicode-J-1"/>
+      <xs:enumeration value="UTF-7" />-\->
+      <xs:enumeration value="UTF-8" />
+<!-\-      <xs:enumeration value="UTF-16" />
+      <xs:enumeration value="UTF-16BE"/>
+      <xs:enumeration value="UTF-16LE"/>
+      <xs:enumeration value="ISO-8859-1" />
+      <xs:enumeration value="ISO-8859-2" />
+      <xs:enumeration value="ISO-8859-3" />
+      <xs:enumeration value="ISO-8859-4" />
+      <xs:enumeration value="ISO-8859-5" />
+      <xs:enumeration value="ISO-8859-6" />
+      <xs:enumeration value="ISO-8859-7" />
+      <xs:enumeration value="ISO-8859-8" />
+      <xs:enumeration value="ISO-8859-9" />
+      <xs:enumeration value="ISO-8859-10" />
+      <xs:enumeration value="ISO-8859-11" />
+      <xs:enumeration value="ISO-8859-13"/>
+      <xs:enumeration value="ISO-8859-14" />
+      <xs:enumeration value="ISO-8859-15" />
+      <xs:enumeration value="ISO-8859-16" />
+      <xs:enumeration value="JIS_Encoding" />
+      <xs:enumeration value="Shift_JIS" />
+      <xs:enumeration value="EUC-JP" />
+      <xs:enumeration value="US-ASCII" />
+      <xs:enumeration value="EUC-KR" />
+      <xs:enumeration value="ISO-2022-KR"/>
+      <xs:enumeration value="Big5" />
+      <xs:enumeration value="Big5-HKSCS"/>
+      <xs:enumeration value="ISO-10646-Unicode-Latin1"/>
+      <xs:enumeration value="ISO-10646-J-1"/>
+      <xs:enumeration value="PTCP154"/>
+      <xs:enumeration value="KOI8-U"/>
+      <xs:enumeration value="GB18030"/>-\->
+    </xs:restriction>
+  </xs:simpleType>-->
+  
+  <xs:complexType name="S100_UnitOfMeasure">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="definition" minOccurs="0" type="xs:string"/>        
+      <xs:element name="symbol" minOccurs="0" type="xs:string"/>            
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/1.2.0/FC/S100/S100CD.xsd
+++ b/1.2.0/FC/S100/S100CD.xsd
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © Copyright 2011, 2014-2016,2018, 2022 International Hydrographic Organization 
+License (Draft)
+Certain parts of this document refer to or are based on the standards, documents, schemas,
+or other material of the International Organization for Standardization (ISO), Open Geospatial
+Consortium (OGC), International Hydrographic Organization / Organisation Hydrographique
+Internationale (IHO/OHI).
+The ISO material can be obtained from any ISO member and from the Web site of the ISO Central
+Secretariat at www.iso.org.
+The OGC material can be obtained from the OGC Web site at www.opengeospatial.org.
+The IHO material can be obtained from the IHO Web site at www.iho.int or from the International
+Hydrographic Organization Secretariat.
+
+Permission to copy and distribute this document is hereby granted provided that this notice is
+retained on all copies, and that the IHO is credited when the material is redistributed
+or used in part or whole in derivative works.
+Redistributions in binary form must reproduce this notice in the documentation and/or other
+materials provided with the distribution.
+
+Disclaimer
+This work is provided by the copyright holders and contributors "as is" and any express or implied
+warranties, including, but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be
+liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including,
+but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or
+business interruption) however caused and on any theory of liability, whether in contract, strict
+liability, or tort (including negligence or otherwise) arising in any way out of the use of this
+software, even if advised of the possibility of such damage.
+-->
+<!-- Date: 04 September 2014; Modification: Updated for S-100 Ed. 2.0.0 -->
+<!-- Date: 16 September 2014; Modification: added schema version; spelling corrections -->
+<!-- Date: 2015-09-21 Raphael Malyankar
+  Modifications: S100_ prefixes added to types defined in S-100 (Multiplicity);
+    removed "aggregation" from S100_CD_FeatureUseType;
+    2016-07-15: Updated copyright/license statement
+    Note: This should be updated to use the ISO schemas or a profile of them wherever S-100 is using
+    the ISO type
+    2016-07-21: Added value types beginning with upper case to S100_CD_AttributeValueType (temporary
+      fix(?) to bypass case discrepancy between types in the register model and application schema
+  2017-07-24 (Raphael Malyankar): Removed uppercase value types Text, Real, Boolean, Integer, Enumeration, Date, Time,
+    DateTime from attribute value type enumeration; changed schema version numbering to conform to
+    <S-100 version>-<build date> convention
+  2018-05-02 (Raphael Malyankar): version number update for 4.0
+-->
+<!-- Version 5.0.0 Build 20220331 (Raphael Malyankar) New file for S-10 5.0.0
+  The file S100CD contains only the types from S-100 5.0.0 Edition Parts 2/2a which are used in the S-100 feature catalogue.
+  These types were extracted from the Edition 4.0.0 S100FD.xsd file and updated as specified in Parts 2/2a of S-100 Edition 5.0.0.
+  The import of S100CI is not needed after these changes and has also been removed. 
+  20220610 build: build number updated; import location of S100Base now relative
+-->
+
+  <!-- Prepared for the International Hydrographic Organisation (IHO).
+    Contributors: Holger Bothien (SevenCs/Chartworld); Tom Richardson (UKHO); Sewoong Oh (KRISO);
+    Yong Baek (KHOA); Raphael Malyankar (Jeppesen); Raphael Malyankar (Portolan Sciences LLC)
+  -->
+<xs:schema targetNamespace="http://www.iho.int/S100CD/5.0" elementFormDefault="qualified" 
+           xmlns="http://www.iho.int/S100CD/5.0" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:s100Base="http://www.iho.int/S100Base/5.0" 
+           version="5.0.0-20220610">
+  <xs:import namespace="http://www.iho.int/S100Base/5.0" schemaLocation="S100Base.xsd" />
+
+  <xs:simpleType name="S100_CD_AttributeValueType">
+    <xs:annotation><xs:documentation>Value types of simple attributes</xs:documentation></xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="boolean" ><xs:annotation><xs:documentation>True or False</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="enumeration" ><xs:annotation><xs:documentation>List of predetermined values that can be expanded and contracted</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="integer" ><xs:annotation><xs:documentation>Numeric value with defined range, units and format</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="real" ><xs:annotation><xs:documentation>Floating point number</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="text" ><xs:annotation><xs:documentation>A sequence of characters</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="date" ><xs:annotation><xs:documentation>Character encoding shall follow the format for date as specified by ISO 8601</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="time" ><xs:annotation><xs:documentation>Character encoding shall follow the format for time as specified by ISO 8601</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="dateTime" ><xs:annotation><xs:documentation>Character encoding shall follow the format for date and time as specified by ISO 8601</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="URI" ><xs:annotation><xs:documentation>Character encoding shall follow the format for URI as specified by RFC 3986</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="URL" ><xs:annotation><xs:documentation>Character encoding shall follow the format for URL as specified by RFC 3986</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="URN" ><xs:annotation><xs:documentation>Character encoding shall follow the format for URL as specified by RFC 3986</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="S100_CodeList" ><xs:annotation><xs:documentation>Open enumeration or identifier of entry in a vocabulary</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="S100_TruncatedDate" ><xs:annotation><xs:documentation>Truncated format for date</xs:documentation></xs:annotation></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="S100_CD_FeatureUseType">
+    <xs:annotation><xs:documentation>Categories of feature types</xs:documentation></xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="geographic" ><xs:annotation><xs:documentation>carries the descriptive characteristics of a real world entity</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="meta" ><xs:annotation><xs:documentation>Delineates geographic location where meta information is applicable” distinct from an Information Type which carries information related to features which are related</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="cartographic" ><xs:annotation><xs:documentation>carries information about the cartographic representation (including text) of a real world entity</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="theme" ><xs:annotation><xs:documentation>Grouping features thematically</xs:documentation></xs:annotation></xs:enumeration>    
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="S100_CD_QuantitySpecification">
+    <xs:annotation><xs:documentation>Types of quantity measures</xs:documentation></xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="angularVelocity" ><xs:annotation><xs:documentation>The instantaneous rate of change of angular displacement with time</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="area" ><xs:annotation><xs:documentation>The measure of the physical extent of any two-dimensional geometric object</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="density" ><xs:annotation><xs:documentation>Mass per unit volume; number per unit area. Also: specific gravity (S-32). Density of soundings is the intervals between lines of sounding and soundings in the same line (S-32)</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="duration" ><xs:annotation><xs:documentation>Interval of time</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="frequency" ><xs:annotation><xs:documentation>Number of vibrations or cycles per unit time</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="length" ><xs:annotation><xs:documentation>The longest dimension of an object; distance measured along a line or curve</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="mass" ><xs:annotation><xs:documentation>A numerical measure of the inertia of an object; the quantity of matter which a body contains, irrespective of its bulk or volume</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="planeAngle" ><xs:annotation><xs:documentation>The amount of rotation needed to bring one line or plane into coincidence with another, generally measured in radians or degrees</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="power" ><xs:annotation><xs:documentation>Rate of doing work or transferring energy; magnification</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="pressure" ><xs:annotation><xs:documentation>Force per unit area</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="salinity" ><xs:annotation><xs:documentation>A measure of the quantity of dissolved salts</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="speed" ><xs:annotation><xs:documentation>Rate of change of position with time</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="temperature" ><xs:annotation><xs:documentation>The intensity or degree of heat</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="volume" ><xs:annotation><xs:documentation>The measure of the physical space of any 3-D geometric object</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="weight" ><xs:annotation><xs:documentation>The force experienced by an object due to gravity</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="otherQuantity" ><xs:annotation><xs:documentation>A quantity different from the other literals of this enumeration</xs:documentation></xs:annotation></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="S100_CD_AttributeConstraints">
+    <xs:annotation><xs:documentation>Constraints of a simple attribute</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element name="stringLength" type="xs:positiveInteger" maxOccurs="1" minOccurs="0" ><xs:annotation><xs:documentation>Shall be represented as a positive integer (that is, greater than zero) that specifies the maximum number of characters that may be assigned to the text attribute type. If not specified, then the text length shall be unconstrained</xs:documentation></xs:annotation></xs:element>
+      <xs:element name="textPattern" type="xs:string" maxOccurs="1" minOccurs="0" ><xs:annotation><xs:documentation>A character string that specifies a scheme of one or more constraints on the structure of the text values that may be assigned to the attribute. This shall be achieved by using a regular expression. W3C XML Schema Part 2: Datasets Second Edition, Appendix F (Regular Expressions) shall be used to define text patterns in this standard</xs:documentation></xs:annotation></xs:element>
+      <xs:element name="range" type="s100Base:S100_NumericRange" maxOccurs="1" minOccurs="0" ><xs:annotation><xs:documentation>Specifies the range of allowed numeric values</xs:documentation></xs:annotation></xs:element>
+      <xs:element name="precision" type="xs:nonNegativeInteger" maxOccurs="1" minOccurs="0"><xs:annotation><xs:documentation>Specifies the precision of a real number</xs:documentation></xs:annotation></xs:element> 
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/1.2.0/FC/S100/S100CI.xsd
+++ b/1.2.0/FC/S100/S100CI.xsd
@@ -1,0 +1,952 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © Copyright 2011, 2014-2016,2018, 2022 International Hydrographic Organisation
+License (Draft)
+Certain parts of this document refer to or are based on the standards, documents, schemas,
+or other material of the International Organization for Standardization (ISO), Open Geospatial
+Consortium (OGC), International Hydrographic Organization / Organisation Hydrographique
+Internationale (IHO/OHI).
+The ISO material can be obtained from any ISO member and from the Web site of the ISO Central
+Secretariat at www.iso.org.
+The OGC material can be obtained from the OGC Web site at www.opengeospatial.org.
+The IHO material can be obtained from the IHO Web site at www.iho.int or from the International
+Hydrographic Organization Secretariat.
+
+Permission to copy and distribute this document is hereby granted provided that this notice is
+retained on all copies, and that the IHO is credited when the material is redistributed
+or used in part or whole in derivative works.
+Redistributions in binary form must reproduce this notice in the documentation and/or other
+materials provided with the distribution.
+
+Disclaimer
+This work is provided by the copyright holders and contributors "as is" and any express or implied
+warranties, including, but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be
+liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including,
+but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or
+business interruption) however caused and on any theory of liability, whether in contract, strict
+liability, or tort (including negligence or otherwise) arising in any way out of the use of this
+software, even if advised of the possibility of such damage.
+-->
+<!-- Date: 04 September 2014; Modification: Updated for S-100 Ed. 2.0.0
+
+-->
+<!-- Date: 16 September 2014; Modification: added schema version; -->
+<!-- 2015-09-21 Raphael Malyankar Added MD_ClassificationCode enumeration; correct spelling of literal "distributor" in RoleCode
+     2016-07-15: Updated copyright/license statement
+     Note: This should be updated to use the ISO schemas or a profile of them wherever S-100 is using the ISO type
+  2018-05-02 (Raphael Malyankar): Note about correcting Citation/aternateTitle to alternateTitle (not corrected pending
+      coordination with FCB); version number update for 4.0.
+  2018-06-12: updated for harmonization with 19115-3:
+    added nilreason attribute (this is ultimately needed because 19115-3 made role mandatory in CI_Responsibility);
+    replaced CI_ResponsibleParty with CI_Responsibility and subordinate classes CI_Individual and CI_Organisation;
+    added new 19115-1 literals to RoleCode, DateTypeCode, PresentationFormCode, MD_ClassificationCode;
+    removed the optional collectiveTitle attribute from Citation (it is not an attribute in 19115-1);
+    revised structure of telephone element to conform to 19115-1
+    Note: The structure conforms to 19115-1 and 19115-3 with the following differences, so as to minimize changes to the FCB:
+    (1) the ...PropertyType types in 19115-3 citations are generally not used, instead the basic types are used as element
+        types; the result is that the outermost ISO 19115-3 XML tags do not appear in the file. E.g., identifiers are not
+        wrapped in "MD_Identifier" tags. This was done for consistency with previous editions of the FC schemas, but
+        can be revised if convenient for implementations.
+    (2) the multiplicities of some elements have been restricted compared to 19115-1/19115-3 (including removal of
+        some optional elements;
+    (3) the nilreason attribute is allowed only for a limited set of elements, rather than generally allowed as in 19115-3;
+    (4) the allowed space of nilreason attributes is limited to the 19115-3 explicitly listed codes (the xs:anyURI or the
+        free pattern for other: ... specified in 19115-3 schemas are not allowed)
+ -->
+<!-- 2022-03031: Updated for S-100 5.0.0.
+    Modifications: Namespace updated
+    20220610: build in version number updated due to update in S100FC.xsd
+ -->
+  <!-- Prepared for the International Hydrographic Organisation (IHO).
+    Contributors: Holger Bothien (SevenCs/Chartworld); Tom Richardson (UKHO); Sewoong Oh (KRISO);
+    Yong Baek (KHOA); Raphael Malyankar (Jeppesen); Raphael Malyankar (Portolan Sciences LLC)
+  -->
+<xs:schema targetNamespace="http://www.iho.int/S100CI/5.0"
+  elementFormDefault="qualified"
+  xmlns="http://www.iho.int/S100CI/5.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  version="5.0.0-2022610">
+
+  <!-- The nil reason attribute defiitions are taken from the ISO 19115-3 gco namespace and restricted to disallow "anyURI" and the "other: " pattern as allowed values"  -->
+  <!--================== NULL ====================-->
+  <xs:attribute name="nilReason" type="NilReasonType"/>
+  
+  <xs:simpleType name="NilReasonType">
+    <xs:annotation>
+      <xs:documentation>copied from gml32:NilReasonType. This Type defines a content model that allows recording of an 
+        explanation for a void value or other exception.
+        gml:NilReasonType is a union of the following enumerated values:
+        -	inapplicable- there is no value
+        -	missing- the correct value is not readily available to the sender of this data. Furthermore, a correct value may not exist
+        -	template- the value will be available later
+        -	unknown- the correct value is not known to, and not computable by, the sender of this data. However, a correct value probably exists
+        -	withheld- the value is not divulged
+        -	other:text - other brief explanation, where text is a string of two or more characters with no included spaces
+        and
+        -	xs:anyURI which should refer to a resource which describes the reason for the exception
+        A particular community may choose to assign more detailed semantics to the standard values provided. Alternatively, the URI method enables a specific or more complete explanation for the absence of a value to be provided elsewhere and indicated by-reference in an instance document.
+        gml:NilReasonType is used as a member of a union in a number of simple content types where it is necessary to permit a value from the NilReasonType union as an alternative to the primary type.</xs:documentation>
+      <xs:documentation>S-100 note: other:text and xs:anyURI are not allowed</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="NilReasonEnumeration"/>
+  </xs:simpleType>
+  <xs:simpleType name="NilReasonEnumeration">
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="inapplicable"/>
+          <xs:enumeration value="missing"/>
+          <xs:enumeration value="template"/>
+          <xs:enumeration value="unknown"/>
+          <xs:enumeration value="withheld"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <!--<xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="other:\w{2,}"/>
+        </xs:restriction>
+      </xs:simpleType>-->
+    </xs:union>
+  </xs:simpleType>
+  
+  <xs:simpleType name="DateTypeCode">
+  <xs:annotation>
+    <xs:documentation>identification of when a given event occurred</xs:documentation>
+    <xs:documentation>V 4.0.0: added codes expiry, lastUpdate, lastRevision, nextUpdate, unavailable, inforce, adopted, deprecated, superseded, validityBegins, validityExpires, released, distribution (all in 19115-1); added definitions</xs:documentation>
+  </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="creation">
+        <xs:annotation>
+          <xs:documentation>date identifies when the resource was brought into existence</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publication">
+        <xs:annotation>
+          <xs:documentation>date identifies when the resource was issued</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="revision">
+        <xs:annotation>
+          <xs:documentation>date identifies when the resource was examined or re-examined and improved or amended</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="expiry">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource expires</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lastUpdate">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource was last updated</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lastRevision">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource was last reviewed</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nextUpdate">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource will be next updated</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unavailable">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource became not available or obtainable</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inForce">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource became in force</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="adopted">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource was adopted</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="deprecated">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource was deprecated</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="superseded">
+        <xs:annotation>
+          <xs:documentation>date identifies when resource was  superseded or replaced by another resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="validityBegins">
+        <xs:annotation>
+          <xs:documentation>time at which the data are considered to become valid.  NOTE: There could be quite a delay between creation and validity begins</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="validityExpires">
+        <xs:annotation>
+          <xs:documentation>time at which the data are no longer considered to be valid</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="released">
+        <xs:annotation>
+          <xs:documentation>the date that the resource shall be released for public access</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="distribution">
+        <xs:annotation>
+          <xs:documentation>date identifies when an instance of the resource was distributed</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="dateExt">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="date" type="xs:date"/>
+        <xs:element name="yearMonth" type="xs:gYearMonth"/>
+        <xs:element name="year" type="xs:gYear"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Date">
+  <xs:annotation><xs:documentation>S100 differs from ISO 19115-1/3 in allowing reduced forms for date</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element name="date" type="dateExt" nillable="true"/>
+      <xs:element name="dateType" type="DateTypeCode"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- ============================================= -->
+  <!-- 19115-1 codelists encoded as XML enumerations -->
+  <!-- ============================================= -->
+  <xs:simpleType name="PresentationFormCode">
+    <xs:annotation>
+      <xs:documentation>mode in which the data are represented</xs:documentation>
+      <xs:documentation>V. 4.0.0: added imageHardcopy, multimediaDigital, multimediaHardcopy, diagramDigital, diagramHardcopy (all in 19115-1, the latter 4 being new in 19115-1); added definitions. The 19115-1 entries audioDigital, audioHardCopy, physicalSample were deliberately omitted as being inapplicable to S-100. The source is the codelists.xml resources file distributed by ISO with the 19115-3 schemas.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="documentDigital">
+        <xs:annotation>
+          <xs:documentation>digital representation of a primarily textual item (can contain illustrations also)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="documentHardcopy">
+        <xs:annotation>
+          <xs:documentation>representation of a primarily textual item (can contain illustrations also) on paper, photographic material, or other media</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="imageDigital">
+        <xs:annotation>
+          <xs:documentation>likeness of natural or man-made features, objects, and activities acquired through the sensing of visual or any other segment of the electromagnetic spectrum by sensors, such as thermal infrared, and high resolution radar and stored in digital format</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="imageHardcopy">
+        <xs:annotation>
+          <xs:documentation>likeness of natural or man-made features, objects, and activities acquired through the sensing of visual or any other segment of the electromagnetic spectrum by sensors, such as thermal infrared, and high resolution radar and reproduced on paper, photographic material, or other media for use directly by the human user</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mapDigital">
+        <xs:annotation>
+          <xs:documentation>map represented in raster or vector form</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mapHardcopy">
+        <xs:annotation>
+          <xs:documentation>map printed on paper, photographic material, or other media for use directly by the human user</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="modelDigital">
+        <xs:annotation>
+          <xs:documentation>multi-dimensional digital representation of a feature, process, etc.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="modelHardcopy">
+        <xs:annotation>
+          <xs:documentation>3-dimensional, physical model</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="profileDigital">
+        <xs:annotation>
+          <xs:documentation>vertical cross-section in digital form</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="profileHardcopy">
+        <xs:annotation>
+          <xs:documentation>vertical cross-section printed on paper, etc.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tableDigital">
+        <xs:annotation>
+          <xs:documentation>digital representation of facts or figures systematically displayed, especially in columns</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tableHardcopy">
+        <xs:annotation>
+          <xs:documentation>representation of facts or figures systematically displayed, especially in columns, printed on paper, photographic material, or other media</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="videoDigital">
+        <xs:annotation>
+          <xs:documentation>digital video recording</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="videoHardcopy">
+        <xs:annotation>
+          <xs:documentation>video recording on film</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="multimediaDigital">
+        <xs:annotation>
+          <xs:documentation>information representation using simultaneously various digital modes for text, sound, image</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="multimediaHardcopy">
+        <xs:annotation>
+          <xs:documentation>information representation using simultaneously various analog modes for text, sound, image</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="diagramDigital">
+        <xs:annotation>
+          <xs:documentation>information represented graphically by charts such as pie chart, bar chart, and other type of diagrams and recorded in digital format</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="diagramHardcopy">
+        <xs:annotation>
+          <xs:documentation>information represented graphically by charts such as pie chart, bar chart, and other type of diagrams and printed on paper, photographic material, or other media</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="S100_RoleCode_PropertyType">
+  <xs:annotation><xs:documentation>The rolecode property is for use when roles must be allowed to be nilled.</xs:documentation></xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="RoleCode">
+        <xs:attribute ref="nilReason" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+
+  <xs:simpleType name="RoleCode">
+    <xs:annotation>
+      <xs:documentation>function performed by the responsible party</xs:documentation>
+      <xs:documentation>V. 4.0.0: added author, sponsor, coAuthor, collaborator, editor, mediator, rightsHolder, contributor, funder, stakeholder (19115-1); added definitions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="resourceProvider">
+        <xs:annotation>
+          <xs:documentation>party that supplies the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="custodian">
+        <xs:annotation>
+          <xs:documentation>party that accepts accountability and responsibility for the resource and ensures appropriate care and maintenance of the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="owner">
+        <xs:annotation>
+          <xs:documentation>party that owns the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="user">
+        <xs:annotation>
+          <xs:documentation>party who uses the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="distributor">
+        <xs:annotation>
+          <xs:documentation>party who distributes the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="originator">
+        <xs:annotation>
+          <xs:documentation>party who created the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pointOfContact">
+        <xs:annotation>
+          <xs:documentation>party who can be contacted for acquiring knowledge about or acquisition of the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="principalInvestigator">
+        <xs:annotation>
+          <xs:documentation>key party responsible for gathering information and conducting research</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="processor">
+        <xs:annotation>
+          <xs:documentation>party who has processed the data in a manner such that the resource has been modified</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publisher">
+        <xs:annotation>
+          <xs:documentation>party who published the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="author">
+        <xs:annotation>
+          <xs:documentation>party who authored the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sponsor">
+        <xs:annotation>
+          <xs:documentation>party who speaks for the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="coAuthor">
+        <xs:annotation>
+          <xs:documentation>party who jointly authors the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="collaborator">
+        <xs:annotation>
+          <xs:documentation>party who assists with the generation of the resource other than the principal investigator</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="editor">
+        <xs:annotation>
+          <xs:documentation>party who reviewed or modified the resource to improve the content</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mediator">
+        <xs:annotation>
+          <xs:documentation>a class of entity that mediates access to the resource and for whom the resource is intended or useful</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rightsHolder">
+        <xs:annotation>
+          <xs:documentation>party owning or managing rights over the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="contributor">
+        <xs:annotation>
+          <xs:documentation>party contributing to the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="funder">
+        <xs:annotation>
+          <xs:documentation>party providing monetary support for the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="stakeholder">
+        <xs:annotation>
+          <xs:documentation>party who has an interest in the resource or the use of the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="OnlineFunctionCode">
+    <xs:annotation><xs:documentation>function performed by the resource</xs:documentation>
+      <xs:documentation>V 4.0.0: Added 19115-1 literals completeMetadata, browseGraphic, upload, emailService, browsing, fileAccess; added definitions</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="download">
+        <xs:annotation>
+          <xs:documentation>online instructions for transferring data from one storage device or system to another</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="information">
+        <xs:annotation>
+          <xs:documentation>online information about the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="offlineAccess">
+        <xs:annotation>
+          <xs:documentation>online instructions for requesting the resource from the provider</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order">
+        <xs:annotation>
+          <xs:documentation>online order process for obtaining the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="search">
+        <xs:annotation>
+          <xs:documentation>online search interface for seeking out information about the resource</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="completeMetadata">
+        <xs:annotation>
+          <xs:documentation>complete metadata provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="browseGraphic">
+        <xs:annotation>
+          <xs:documentation>browse graphic provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="upload">
+        <xs:annotation>
+          <xs:documentation>online resource upload capability provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="emailService">
+        <xs:annotation>
+          <xs:documentation>online email service provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="browsing">
+        <xs:annotation>
+          <xs:documentation>online browsing provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fileAccess">
+        <xs:annotation>
+          <xs:documentation>online file access provided</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="MD_ClassificationCode">
+    <xs:annotation>
+      <xs:documentation>name of the handling restrictions on the resource</xs:documentation>
+      <xs:documentation>V 4.0.0: Added 19115-1 literals sensitiveButUnclassified (ISO codelists have "SBU", but the ISO UML model has "sensitiveButUnclassified"), forOfficialUseOnly, protected, limitedDistribution</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="unclassified">
+        <xs:annotation>
+          <xs:documentation>available for general disclosure</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="restricted">
+        <xs:annotation>
+          <xs:documentation>not for general disclosure</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="confidential">
+        <xs:annotation>
+          <xs:documentation>available for someone who can be entrusted with information</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="secret">
+        <xs:annotation>
+          <xs:documentation>kept or meant to be kept private, unknown, or hidden from all but a select group of people</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="topSecret">
+        <xs:annotation>
+          <xs:documentation>of the highest secrecy</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sensitiveButUnclassified">
+        <xs:annotation>
+          <xs:documentation>although unclassified, requires strict controls over its distribution</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="forOfficialUseOnly">
+        <xs:annotation>
+          <xs:documentation>unclassified information that is to be used only for official purposes determined by the designating body</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="protected">
+        <xs:annotation>
+          <xs:documentation>compromise of the information could cause damage</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="limitedDistribution">
+        <xs:annotation>
+          <xs:documentation>dissemination limited by designating body</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="TelephoneTypeCode">
+    <xs:annotation>
+      <xs:documentation>type of telephone</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="voice">
+        <xs:annotation>
+          <xs:documentation>telephone provides voice service</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fax">
+        <xs:annotation>
+          <xs:documentation>telephone provides facsimile service</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sms">
+        <xs:annotation>
+          <xs:documentation>telephone provides sms service</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- ============================================= -->
+  <!-- complex types                         -->
+  <!-- ============================================= -->
+  <xs:complexType name="CI_Series_Type">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="issueIdentification" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="page" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CI_OnlineResource_Type">
+    <xs:annotation><xs:documentation>V 4.0.0: attribute url from S-100 3.0.0 replaced by linkage to conform to 19115-1. The optional protocolRequest attribute is not used because it was not in previous versions of this file and is not expected to be required in feature catalogues.</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element name="linkage" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="protocol" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="applicationProfile" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="function" type="OnlineFunctionCode" minOccurs="0" maxOccurs="1"/>
+<!--
+      <element minOccurs="0" name="protocolRequest" type="gco:CharacterString_PropertyType">
+        <annotation>
+          <documentation>protocol used by the accessed resource</documentation>
+        </annotation>
+      </element>
+-->
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CI_Address_Type">
+    <xs:annotation>
+      <xs:documentation>From 19115-3 schemas with inheritance from gco:AbstractObjectType removed and gco:characterstring properties replaced by xs:string</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="deliveryPoint" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>address line for the location (as described in ISO 11180, Annex A)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="city" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>city of the location</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="administrativeArea" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>state, province of the location</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="postalCode" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>ZIP or other postal code</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="country" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>country of the physical address</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="electronicMailAddress" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>address of the electronic mailbox of the responsible organisation or individual</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CI_Citation_Type">
+    <xs:annotation>
+      <xs:documentation>standardized resource reference</xs:documentation>
+      <xs:documentation>V. 4.0.0: removed collectiveTitle (not in 19115-1 / 19115-3); intentionally omitted the optional 19115-3 element "graphic" to reduce changes to feature catalogues and the FCB</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="title" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>name by which the cited resource is known</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="alternateTitle" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>short name or other language name by which the cited information is known. Example: DCW as an alternative title for Digital Chart of the World</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="date" type="Date">
+        <xs:annotation>
+          <xs:documentation>reference date for the cited resource</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="edition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>version of the cited resource</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="editionDate" type="dateExt">
+        <xs:annotation>
+          <xs:documentation>date of the edition. type differs from ISO 19115-3 in being a complex type and allowing one of date, yearMonth, or year as in S-100 3.0.0 </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="1" minOccurs="0" name="identifier" type="MD_Identifier_Type">
+        <xs:annotation>
+          <xs:documentation>value uniquely identifying an object within a namespace</xs:documentation>
+          <xs:documentation>S-100 type and maxOccurs differ from ISO 19115-3 in using only string types and not using the "authority" citation within identifier elements</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="citedResponsibleParty" type="CI_Responsibility_PropertyType">
+        <xs:annotation>
+          <xs:documentation>name and position information for an individual or organisation that is responsible for the resource</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="presentationForm" type="PresentationFormCode">
+        <xs:annotation>
+          <xs:documentation>mode in which the resource is represented</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="series" type="CI_Series_Type">
+        <xs:annotation>
+          <xs:documentation>information about the series, or aggregate resource, of which the resource is a part</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="otherCitationDetails" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>other information required to complete the citation that is not recorded elsewhere</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ISBN" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>international Standard Book Number</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="ISSN" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>international Standard Serial Number</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="onlineResource" type="CI_OnlineResource_Type">
+        <xs:annotation>
+          <xs:documentation>online reference to the cited resource</xs:documentation>
+            </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CI_Responsibility_PropertyType">
+    <xs:annotation><xs:documentation>S-100 V. 4.0.0: use of references and nilling not allowed when used in S-100 feature catalogues</xs:documentation></xs:annotation>
+    <xs:sequence minOccurs="0">
+      <xs:element ref="CI_Responsibility"/>
+    </xs:sequence>
+    <!--    <attributeGroup ref="gco:ObjectReference"/>
+    <attribute ref="gco:nilReason"/>-->
+  </xs:complexType>
+
+  <xs:element name="CI_Responsibility" type="CI_Responsibility_Type">
+    <xs:annotation>
+      <xs:documentation>information about the party and their role</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:complexType name="CI_Responsibility_Type">
+    <xs:annotation><xs:documentation>information about the party and their role</xs:documentation>
+      <xs:documentation>Beginning V. 4.0.0, this is as defined in 19115-3 with the optional "extent" attribute omitted.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="role" type="S100_RoleCode_PropertyType">
+        <xs:annotation>
+          <xs:documentation>function performed by the responsible party</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <!--<xs:element maxOccurs="unbounded" minOccurs="0" name="extent" type="mcc:Abstract_Extent_PropertyType">
+        <xs:annotation>
+          <xs:documentation>spatial or temporal extent of the role</xs:documentation>
+        </xs:annotation>
+      </xs:element>-->
+      <xs:element maxOccurs="unbounded" name="party" type="AbstractCI_Party_PropertyType"/>
+    </xs:sequence>
+
+
+  </xs:complexType>
+
+  <xs:element abstract="true" name="AbstractCI_Party" type="AbstractCI_Party_Type">
+    <xs:annotation>
+      <xs:documentation>information about the individual and/or organisation of the party</xs:documentation>
+      <xs:documentation>V 4.0.0: object reference and nilling not used in S-100 feature catalogues</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="AbstractCI_Party_PropertyType">
+    <xs:sequence minOccurs="0">
+      <xs:element ref="AbstractCI_Party"/>
+    </xs:sequence>
+    <!--    <xs:attributeGroup ref="gco:ObjectReference"/>
+    <xs:attribute ref="gco:nilReason"/>-->
+  </xs:complexType>
+
+  <xs:complexType abstract="true" name="AbstractCI_Party_Type">
+    <xs:annotation><xs:documentation>partyIdentifier type made xs:string consistent with other identifiers in the feature catalogue</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="0" name="name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>name of the party</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="contactInfo" type="CI_Contact_Type">
+        <xs:annotation>
+          <xs:documentation>contact information for the party</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="partyIdentifier" type="MD_Identifier_Type">
+        <xs:annotation>
+          <xs:documentation>value uniquely identifying a party (individual or organization)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- from 1915-3 mcc namespace -->
+  <xs:complexType name="MD_Identifier_Type">
+    <xs:annotation><xs:documentation>S-100 feature catalogues use a simplified form in using only string identifiers. The optional "authority" citation is not used.</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <!--<xs:element minOccurs="0" name="authority" type="mcc:Abstract_Citation_PropertyType">
+        <xs:annotation>
+          <xs:documentation>Citation for the code namespace and optionally the person or party responsible for maintenance of that namespace</xs:documentation>
+            </xs:annotation>
+          </xs:element>-->
+      <xs:element name="code" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>alphanumeric value identifying an instance in the namespace e.g. EPSG::4326</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="codeSpace" type="xs:string">
+        <xs:annotation>
+              <xs:documentation>Identifier or namespace in which the code is valid</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="version" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>version identifier for the namespace</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>natural language description of the meaning of the code value E.G for codeSpace = EPSG, code = 4326: description = WGS-84" to "for codeSpace = EPSG, code = EPSG::4326: description = WGS-84</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:element name="CI_Individual" substitutionGroup="AbstractCI_Party" type="CI_Individual_Type">
+    <xs:annotation>
+      <xs:documentation>information about the party if the party is an individual</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="CI_Individual_PropertyType">
+    <xs:sequence minOccurs="0">
+      <xs:element ref="CI_Individual"/>
+    </xs:sequence>
+    <!--    <attributeGroup ref="gco:ObjectReference"/>
+    <attribute ref="gco:nilReason"/>-->
+  </xs:complexType>
+  <xs:complexType name="CI_Individual_Type">
+    <xs:complexContent>
+      <xs:extension base="AbstractCI_Party_Type">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="positionName" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>position of the individual in an organisation</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="CI_Organisation" substitutionGroup="AbstractCI_Party" type="CI_Organisation_Type">
+    <xs:annotation>
+      <xs:documentation>information about the party if the party is an organisation</xs:documentation>
+      <xs:documentation>V 4.0.0: "graphic" attribute is not used in S-100 feature catalogues</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="CI_Organisation_Type">
+    <xs:complexContent>
+      <xs:extension base="AbstractCI_Party_Type">
+        <xs:sequence>
+          <!--<xs:element maxOccurs="unbounded" minOccurs="0" name="logo" type="mcc:MD_BrowseGraphic_PropertyType">
+            <xs:annotation>
+              <xs:documentation>Graphic identifying organization</xs:documentation>
+            </xs:annotation>
+          </xs:element>-->
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="individual" type="CI_Individual_PropertyType"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+
+  <xs:complexType name="CI_Contact_Type">
+    <xs:annotation><xs:documentation>information required to enable contact with the responsible person and/or organisation</xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="phone" type="CI_Telephone_Type">
+        <xs:annotation>
+          <xs:documentation>telephone numbers at which the organisation or individual may be contacted</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="address" type="CI_Address_Type">
+        <xs:annotation>
+          <xs:documentation>physical and email address at which the organisation or individual may be contacted</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="onlineResource" type="CI_OnlineResource_Type">
+        <xs:annotation>
+          <xs:documentation>on-line information that can be used to contact the individual or organisation</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="hoursOfService" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>time period (including time zone) when individuals can contact the organisation or individual</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="contactInstructions" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>supplemental instructions on how or when to contact the individual or organisation</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="contactType" type="xs:string"><xs:annotation><xs:documentation>type of the contact</xs:documentation></xs:annotation></xs:element>
+        </xs:sequence>
+      
+    
+  </xs:complexType>
+
+  <xs:complexType name="CI_Telephone_Type">
+ 
+   
+    <xs:sequence>
+      <xs:element name="number" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>telephone number by which individuals can contact responsible organisation or individual</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+      <xs:element minOccurs="0" name="numberType" type="TelephoneTypeCode">
+        <xs:annotation>
+          <xs:documentation>type of telephone responsible organisation or individual</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      
+    
+  </xs:complexType>
+
+
+  <!-- from baseTypes2014 -->
+  <!-- =========================== Date & DateTime ================================= -->
+  <!--=============================================-->
+  <!--<xs:element name="DateTime" type="xs:dateTime"/>-->
+  <!-- ........................................................................ -->
+  <!--<xs:complexType name="DateTime_PropertyType">
+    <xs:sequence minOccurs="0">
+      <xs:element ref="DateTime"/>
+    </xs:sequence>
+    <!-\-<xs:attribute ref="gco:nilReason"/>-\->
+  </xs:complexType>-->
+  <!-- =========================================================================== -->
+  <!--<xs:simpleType name="Date_Type">
+    <xs:union memberTypes="xs:date xs:gYearMonth xs:gYear"/>
+  </xs:simpleType>-->
+  <!-- ........................................................................ -->
+  <!--<xs:element name="Date" type="Date_Type" nillable="true"/>-->
+  <!-- ........................................................................ -->
+  <!--<xs:complexType name="Date_PropertyType">
+    <xs:choice minOccurs="0">
+      <xs:element ref="Date"/>
+      <xs:element ref="DateTime"/>
+    </xs:choice>
+    <!-\-<xs:attribute ref="gco:nilReason"/>-\->
+  </xs:complexType>-->
+
+</xs:schema>

--- a/1.2.0/FC/S100/S100FC.xsd
+++ b/1.2.0/FC/S100/S100FC.xsd
@@ -1,0 +1,608 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © Copyright 2011, 2014-2016,2018,2022 International Hydrographic Organization
+License
+Certain parts of this document refer to or are based on the standards, documents, schemas,
+or other material of the International Organization for Standardization (ISO), Open Geospatial
+Consortium (OGC), International Hydrographic Organization / Organisation Hydrographique
+Internationale (IHO/OHI).
+The ISO material can be obtained from any ISO member and from the Web site of the ISO Central
+Secretariat at www.iso.org.
+The OGC material can be obtained from the OGC Web site at www.opengeospatial.org.
+The IHO material can be obtained from the IHO Web site at www.iho.int or from the International
+Hydrographic Organization Secretariat.
+
+Permission to copy and distribute this document is hereby granted provided that this notice is
+retained on all copies, and that the IHO is credited when the material is redistributed
+or used in part or whole in derivative works.
+Redistributions in binary form must reproduce this notice in the documentation and/or other
+materials provided with the distribution.
+
+Disclaimer
+This work is provided by the copyright holders and contributors "as is" and any express or implied
+warranties, including, but not limited to, the implied warranties of merchantability and fitness
+for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be
+liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including,
+but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or
+business interruption) however caused and on any theory of liability, whether in contract, strict
+liability, or tort (including negligence or otherwise) arising in any way out of the use of this
+software, even if advised of the possibility of such damage.
+-->
+<!-- Original: S-100 Feature Catalogue Schema Version 0.9.4 from 17. June 2011  -->
+<!-- Date: 04 September 2014; Modification: Updated for S-100 Ed. 2.0.0 -->
+<!-- Date: 16 September 2014;
+  Modification: Removed S100_FC_Cataloginfo and moved its sub-elements to S100_FC_Catalogue;
+    Removed dataset attributes; updated header comments; added schema version;
+    Corrected definition source constraints and removed numeric code and unused constraints for numeric codes;
+    multiplicity of S100_FC_Item/remarks and S100_FC_Listedvalue/remarks updated to 0..1 conforming to Hamburg meeting decisions;
+    maxOccurs of permittedPrimitives changed from 5 to 7;
+    multiplicity of S100_FC_FeatureCatalogue/S100_FC_FeatureTypes changed from 1 to 0 (theoretically a catalogue can define only information types and attributes).
+-->
+<!-- Date: 2015-09-21 Raphael Malyankar
+  Modifications: Changed S100_FC_ComplexAttribute to be an extension of S100_FC_Attribute instead of S100_FC_Item;
+    S100_ prefixes added to types defined in S-100; multiplicity of permittedPrimitives changed from 1..7 to 1..*;
+    test for non-repetition of permittedPrimitives values in a feature type; added classification to S100_FC_FeatureCatalogue
+-->
+<!-- Date: 2016-07-12 Raphael Malyankar
+  Modifications: Added role in information binding; corrected constraint for roles in bindings; updated copyright statement with license+disclaimer
+  Date: 2017-06-29  Raphael Malyankar
+  Modifications: bug fix for rule checking roles; common version numbering scheme for S-100 schemas introduced
+  Date: 2018-05-02  Raphael Malyankar
+  Modifications: removed arc and circle by center point from spatial primitive types; removed obsolete comments; version number updated for edition 4.0;
+    Added checks for supertypes/subtypes
+  Date: 2018-06-12: the type S100CI:ResponsibleParty is obsoleted by 19115-1:2014, replaced with S100CI:Responsiblity
+-->
+
+<!-- Date: 2022-03-25 Raphael Malyankar for IHO
+    Modifications: Updated for S-100 5.0.0.
+      All namespaces now have 5.0 suffix.
+      schemaLocation in import statements updated to use schema server. 
+    Build 20220610: S100_FC_SimpleAttribute.listedValues element multiplicity changed from 0..UNB to 0..1
+      build number in version updatedl imports of S100Base, S100Ci, S100CD made relative
+-->
+
+  <!-- Prepared for the International Hydrographic Organisation (IHO).
+    Contributors: Holger Bothien (SevenCs/Chartworld); Tom Richardson (UKHO); Sewoong Oh (KRISO);
+    Yong Baek (KHOA); Raphael Malyankar (Jeppesen & C-Map); Raphael Malyankar (Portolan Sciences LLC)
+  -->
+<xs:schema targetNamespace="http://www.iho.int/S100FC/5.0"
+  elementFormDefault="qualified"
+  xmlns:S100FC="http://www.iho.int/S100FC/5.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:S100Base="http://www.iho.int/S100Base/5.0"
+  xmlns:S100CI="http://www.iho.int/S100CI/5.0"
+  xmlns:S100CD="http://www.iho.int/S100CD/5.0"
+  version="5.0.0-20220610">
+  <xs:import namespace="http://www.iho.int/S100Base/5.0" schemaLocation="S100Base.xsd"/>
+  <xs:import namespace="http://www.iho.int/S100CI/5.0" schemaLocation="S100CI.xsd"/>
+  <xs:import namespace="http://www.iho.int/S100CD/5.0" schemaLocation="S100CD.xsd"/>
+
+  <!-- enumeration for role types -->
+  <xs:simpleType name="S100_FC_RoleType">
+    <xs:annotation><xs:documentation>Defines the type of an association end (that is, a “role”)</xs:documentation></xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="association"><xs:annotation><xs:documentation>The association end is an ordinary linkage. (In UML terms, the role type is “aggregationKind=ordinary” and the link in a diagram does not have a diamond)</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="aggregation"><xs:annotation><xs:documentation>The association end is a UML aggregation. (In UML terms, the role type is “aggregationKind=aggregation” and the link in a diagram has an unfilled diamond at this association end)</xs:documentation></xs:annotation></xs:enumeration>
+      <xs:enumeration value="composition"><xs:annotation><xs:documentation>The association end is a UML aggregation. (In UML terms, the role type is “aggregationKind=composition” and the link in a diagram has a filled diamond at this association end)</xs:documentation></xs:annotation></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- enumeration of primitive types -->
+  <xs:simpleType name="S100_FC_SpatialPrimitiveType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="noGeometry"/>
+      <xs:enumeration value="point"/>
+      <xs:enumeration value="pointSet"/>
+      <xs:enumeration value="curve"/>
+      <xs:enumeration value="surface"/>
+      <xs:enumeration value="coverage"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- camel case code starting with an upper/lower case letter -->
+  <xs:simpleType name="StringCode">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- a 2 byte positive integer -->
+  <xs:simpleType name="IntegerCode">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:maxExclusive value="65536"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic reference type -->
+  <xs:complexType name="Reference">
+    <xs:attribute name="ref" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- the source of a definition -->
+  <xs:complexType name="FC_DefinitionSource">
+    <xs:sequence>
+      <xs:element name="source" type="S100CI:CI_Citation_Type"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- a reference to a definition source -->
+  <xs:complexType name="FC_DefinitionReference">
+    <xs:sequence>
+      <xs:element name="sourceIdentifier" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="definitionSource" type="S100FC:Reference" minOccurs="1" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- a list of positive integer values -->
+  <xs:complexType name="ValueList">
+    <xs:sequence>
+      <xs:element name="value" type="S100FC:IntegerCode" maxOccurs="unbounded" minOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- permittedValues-->
+  <xs:complexType name="S100_FC_ListedValues">
+    <xs:sequence>
+      <xs:element name="listedValue" type="S100FC:S100_FC_ListedValue" maxOccurs="unbounded" minOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- type for bindings to simple or complex attributes -->
+  <xs:complexType name="S100_FC_AttributeBinding">
+    <xs:sequence>
+      <xs:element name="multiplicity" type="S100Base:S100_Multiplicity" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="permittedValues" type="S100FC:ValueList" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="attribute" type="S100FC:Reference" maxOccurs="1" minOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="sequential" type="xs:boolean" default="false"><xs:annotation><xs:documentation>Describes if the sequence of the attributes is meaningful or not. Applies only to attributes which may occur more than once.</xs:documentation></xs:annotation></xs:attribute>
+  </xs:complexType>
+
+  <!-- type for bindings to information types -->
+  <xs:complexType name="S100_FC_InformationBinding">
+    <xs:sequence>
+      <xs:element name="multiplicity" type="S100Base:S100_Multiplicity" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="association" type="S100FC:Reference" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="role" type="S100FC:Reference" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="informationType" type="S100FC:Reference" maxOccurs="unbounded" minOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="roleType" type="S100FC:S100_FC_RoleType" use="required"/>
+  </xs:complexType>
+
+  <!-- type for bindings to feature types -->
+  <xs:complexType name="S100_FC_FeatureBinding">
+    <xs:sequence>
+      <xs:element name="multiplicity" type="S100Base:S100_Multiplicity" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="association" type="S100FC:Reference" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="role" type="S100FC:Reference" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="featureType" type="S100FC:Reference" maxOccurs="unbounded" minOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="roleType" type="S100FC:S100_FC_RoleType" use="required"/>
+  </xs:complexType>
+
+  <!-- base type for catalogue items with camelCase starting with either lower or upper case -->
+  <xs:complexType name="S100_FC_Item" abstract="true">
+    <xs:sequence>
+      <xs:element name="name" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="definition" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="code" type="S100FC:StringCode" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="remarks" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="alias" type="xs:string" maxOccurs="unbounded" minOccurs="0"/>
+      <xs:element name="definitionReference" type="S100FC:FC_DefinitionReference" maxOccurs="1" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- type for listed values of enumerated attributes -->
+  <xs:complexType name="S100_FC_ListedValue">
+    <xs:sequence>
+      <xs:element name="label" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="definition" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="code" type="S100FC:IntegerCode" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="remarks" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="alias" type="xs:string" maxOccurs="unbounded" minOccurs="0"/>
+      <xs:element name="definitionReference" type="S100FC:FC_DefinitionReference" maxOccurs="1" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- type for a attribute -->
+  <xs:complexType name="S100_FC_Attribute">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_Item"/>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for a simple attribute -->
+  <xs:complexType name="S100_FC_SimpleAttribute">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_Attribute">
+        <xs:sequence>
+          <xs:element name="valueType" type="S100CD:S100_CD_AttributeValueType" maxOccurs="1" minOccurs="1"/>
+          <xs:element name="uom" type="S100Base:S100_UnitOfMeasure" maxOccurs="1" minOccurs="0"/>
+          <xs:element name="quantitySpecification" type="S100CD:S100_CD_QuantitySpecification" minOccurs="0"/>
+          <xs:element name="constraints" type="S100CD:S100_CD_AttributeConstraints" maxOccurs="1" minOccurs="0"/>
+          <xs:element name="listedValues" type="S100FC:S100_FC_ListedValues" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for a complex atttribute -->
+  <xs:complexType name="S100_FC_ComplexAttribute">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_Attribute">
+        <xs:sequence>
+          <xs:element name="subAttributeBinding" type="S100FC:S100_FC_AttributeBinding" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for roles (same as Item but not abstract) -->
+  <xs:complexType name="S100_FC_Role">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_Item"/>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- base type for named types -->
+  <xs:complexType name="S100_FC_NamedType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_Item">
+        <xs:sequence>
+          <xs:element name="attributeBinding" type="S100FC:S100_FC_AttributeBinding" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="isAbstract" default="false"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for information associations -->
+  <xs:complexType name="S100_FC_InformationAssociation">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_NamedType">
+        <xs:sequence>
+          <xs:element name="superType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="subType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="role" type="S100FC:Reference" minOccurs="0" maxOccurs="2"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for feature associations -->
+  <xs:complexType name="S100_FC_FeatureAssociation">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_NamedType">
+        <xs:sequence>
+          <xs:element name="superType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="subType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="role" type="S100FC:Reference" minOccurs="0" maxOccurs="2"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- base type for information types and feature types -->
+  <xs:complexType name="S100_FC_ObjectType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_NamedType">
+        <xs:sequence>
+          <xs:element name="informationBinding" type="S100FC:S100_FC_InformationBinding" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for information types (some as Object type but not abstract) -->
+  <xs:complexType name="S100_FC_InformationType">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_ObjectType">
+        <xs:sequence>
+          <xs:element name="superType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="subType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- type for feature types -->
+  <xs:complexType name="S100_FC_FeatureType">
+    <xs:complexContent>
+      <xs:extension base="S100FC:S100_FC_ObjectType">
+        <xs:sequence>
+          <xs:element name="superType" type="xs:string" minOccurs="0" maxOccurs="1"/>
+          <xs:element name="subType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="featureUseType" type="S100CD:S100_CD_FeatureUseType"/>
+          <xs:element name="featureBinding" type="S100FC:S100_FC_FeatureBinding" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="permittedPrimitives" type="S100FC:S100_FC_SpatialPrimitiveType" minOccurs="1" maxOccurs="unbounded" nillable="false"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- list of definition sources -->
+  <xs:complexType name="S100_FC_DefinitionSources">
+    <xs:sequence>
+      <xs:element name="FC_DefinitionSource" type="S100FC:FC_DefinitionSource" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of simple attributes (for each attribute the codes and name of the listed values must be unique-->
+  <xs:complexType name="S100_FC_SimpleAttributes">
+    <xs:sequence>
+      <xs:element name="S100_FC_SimpleAttribute" type="S100FC:S100_FC_SimpleAttribute" minOccurs="1" maxOccurs="unbounded">
+
+        <xs:unique name="ValueCodeUniqueness">
+          <xs:selector xpath="./S100FC:listedValue"/>
+          <xs:field xpath="S100FC:code"/>
+        </xs:unique>
+
+        <xs:unique name="ValueNameUniqueness">
+          <xs:selector xpath="./S100FC:listedValue"/>
+          <xs:field xpath="S100FC:label"/>
+        </xs:unique>
+
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of complex attributes -->
+  <xs:complexType name="S100_FC_ComplexAttributes">
+    <xs:sequence>
+      <xs:element name="S100_FC_ComplexAttribute" type="S100FC:S100_FC_ComplexAttribute" minOccurs="1" maxOccurs="unbounded">
+        <xs:unique name="SubAttributeCodeUniqueness">
+          <xs:selector xpath="./S100FC:subAttributeBinding/S100FC:attribute"/>
+          <xs:field xpath="@ref"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of roles -->
+  <xs:complexType name="S100_FC_Roles">
+    <xs:sequence>
+      <xs:element name="S100_FC_Role" type="S100FC:S100_FC_Role" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of information associations -->
+  <xs:complexType name="S100_FC_InformationAssociations">
+    <xs:sequence>
+      <xs:element name="S100_FC_InformationAssociation" type="S100FC:S100_FC_InformationAssociation" minOccurs="1" maxOccurs="unbounded">
+        <xs:unique name="IA_AttributeCodeUniqueness">
+          <xs:selector xpath="./S100FC:attributeBinding/S100FC:attribute"/>
+          <xs:field xpath="@ref"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of feature associations -->
+  <xs:complexType name="S100_FC_FeatureAssociations">
+    <xs:sequence>
+      <xs:element name="S100_FC_FeatureAssociation" type="S100FC:S100_FC_FeatureAssociation" minOccurs="1" maxOccurs="unbounded">
+        <xs:unique name="FA_AttributeCodeUniqueness">
+          <xs:selector xpath="./S100FC:attributeBinding/S100FC:attribute"/>
+          <xs:field xpath="@ref"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of information types -->
+  <xs:complexType name="S100_FC_InformationTypes">
+    <xs:sequence>
+      <xs:element name="S100_FC_InformationType" type="S100FC:S100_FC_InformationType" minOccurs="1" maxOccurs="unbounded">
+        <xs:unique name="IT_AttributeCodeUniqueness">
+          <xs:selector xpath="./S100FC:attributeBinding/S100FC:attribute"/>
+          <xs:field xpath="@ref"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- list of feature types -->
+  <xs:complexType name="S100_FC_FeatureTypes">
+    <xs:sequence>
+      <xs:element name="S100_FC_FeatureType" type="S100FC:S100_FC_FeatureType" minOccurs="1" maxOccurs="unbounded">
+        <xs:unique name="FT_AttributeCodeUniqueness">
+          <xs:selector xpath="./S100FC:attributeBinding/S100FC:attribute"/>
+          <xs:field xpath="@ref"/>
+        </xs:unique>
+        <xs:unique name="permittedPrimitivesNotRepeated">
+          <xs:selector xpath="./S100FC:permittedPrimitives"/>
+          <xs:field xpath="."/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- The catalogue -->
+  <xs:element name="S100_FC_FeatureCatalogue">
+    <xs:annotation><xs:documentation></xs:documentation></xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="name" type="xs:string" maxOccurs="1" minOccurs="1"/>
+        <xs:element name="scope" type="xs:string" maxOccurs="1" minOccurs="1"/>
+        <xs:element name="fieldOfApplication" type="xs:string" maxOccurs="1" minOccurs="0"/>
+        <xs:element name="versionNumber" type="xs:string" maxOccurs="1" minOccurs="1"/>
+        <xs:element name="versionDate" type="xs:date" maxOccurs="1" minOccurs="1"/>
+        <xs:element name="productId" type="xs:string" minOccurs="1" maxOccurs="1"><xs:annotation><xs:documentation>The ID of the product for which the Catalogue is intended</xs:documentation></xs:annotation></xs:element>
+        <xs:element name="producer" type="S100CI:CI_Responsibility_Type" minOccurs="1" maxOccurs="1"><xs:annotation><xs:documentation>Name, address, country, and telecommunications address of person or organization having primary responsibility for the intellectual content of this Feature Catalogue</xs:documentation></xs:annotation></xs:element>
+        <xs:element name="classification" type="S100CI:MD_ClassificationCode" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_DefinitionSources" type="S100FC:S100_FC_DefinitionSources" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_SimpleAttributes" type="S100FC:S100_FC_SimpleAttributes" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_ComplexAttributes" type="S100FC:S100_FC_ComplexAttributes" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_Roles" type="S100FC:S100_FC_Roles" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_InformationAssociations" type="S100FC:S100_FC_InformationAssociations" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_FeatureAssociations" type="S100FC:S100_FC_FeatureAssociations" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_InformationTypes" type="S100FC:S100_FC_InformationTypes" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="S100_FC_FeatureTypes" type="S100FC:S100_FC_FeatureTypes" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:complexType>
+
+    <!-- defining xs:keys and xs:keyrefs, to avoid limitations of xs:ID and xs:IDREF -->
+
+    <!-- key for definition source ids -->
+    <xs:key name="DefinitionSourceKey">
+      <xs:selector xpath="./S100FC:S100_FC_DefinitionSources/S100FC:FC_DefinitionSource"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+
+    <!-- reference for definition sources -->
+    <xs:keyref refer="S100FC:DefinitionSourceKey" name="DefinitionSourceReference">
+      <xs:selector xpath=".//S100FC:definitionReference/S100FC:definitionSource"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+    <!-- key for simple and complex attributes, values must be unique  -->
+    <xs:key name="AttributeKey">
+      <xs:selector xpath="./S100FC:S100_FC_SimpleAttributes/S100FC:S100_FC_SimpleAttribute | ./S100FC:S100_FC_ComplexAttributes/S100FC:S100_FC_ComplexAttribute"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for attribute codes (each value must be a valid attribute key) -->
+    <xs:keyref refer="S100FC:AttributeKey" name="AttributeRef">
+      <xs:selector xpath=".//S100FC:attributeBinding/S100FC:attribute | .//S100FC:subAttributeBinding/S100FC:attribute"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+    <!-- key for roles-->
+    <xs:key name="RoleKey">
+      <xs:selector xpath="./S100FC:S100_FC_Roles/S100FC:S100_FC_Role"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for roles: from information associations, feature associations, and feature bindings -->
+    <xs:keyref refer="S100FC:RoleKey" name="RoleReference">
+      <xs:selector xpath=".//S100FC:S100_FC_InformationAssociation/S100FC:role | .//S100FC:S100_FC_FeatureAssociation/S100FC:role | .//S100FC:featureBinding/S100FC:role | .//S100FC:informationBinding/S100FC:role"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+    <!-- key for information associations -->
+    <xs:key name="InformationAssociationKey">
+      <xs:selector xpath="./S100FC:S100_FC_InformationAssociations/S100FC:S100_FC_InformationAssociation"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for information associations -->
+    <xs:keyref refer="S100FC:InformationAssociationKey" name="InformationAssociationReference">
+      <xs:selector xpath=".//S100FC:informationBinding/S100FC:association"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+
+    <!-- key for feature associations -->
+    <xs:key name="FeatureAssociationKey">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureAssociations/S100FC:S100_FC_FeatureAssociation"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for feature associations -->
+    <xs:keyref refer="S100FC:FeatureAssociationKey" name="FeatureAssociationReference">
+      <xs:selector xpath=".//S100FC:featureBinding/S100FC:association"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+
+    <!-- key for information types -->
+    <xs:key name="InformationTypeKey">
+      <xs:selector xpath="./S100FC:S100_FC_InformationTypes/S100FC:S100_FC_InformationType"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for information types -->
+    <xs:keyref refer="S100FC:InformationTypeKey" name="InformationTypeReference">
+      <xs:selector xpath=".//S100FC:informationBinding/S100FC:informationType"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+
+
+    <!-- key for feature types -->
+    <xs:key name="FeatureTypeKey">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureTypes/S100FC:S100_FC_FeatureType"/>
+      <xs:field xpath="S100FC:code"/>
+    </xs:key>
+
+    <!-- reference for feature type codes (each value must be a valid feature key -->
+    <xs:keyref refer="S100FC:FeatureTypeKey" name="FeatureRef">
+      <xs:selector xpath=".//S100FC:featureBinding/S100FC:featureType"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+    
+    <!-- reference for supertype and subtype codes (each value must be an appropriate valid type code) -->
+    <xs:keyref refer="S100FC:FeatureTypeKey" name="FeatureSuperTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureTypes/S100FC:S100_FC_FeatureType"/>
+      <xs:field xpath="S100FC:superType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:InformationTypeKey" name="InfoSuperTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_InformationTypes/S100FC:S100_FC_InformationType"/>
+      <xs:field xpath="S100FC:superType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:FeatureTypeKey" name="FeatureSubTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureTypes/S100FC:S100_FC_FeatureType"/>
+      <xs:field xpath="S100FC:subType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:InformationTypeKey" name="InfoSubTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_InformationTypes/S100FC:S100_FC_InformationType"/>
+      <xs:field xpath="S100FC:subType"/>
+    </xs:keyref>
+
+    <xs:keyref refer="S100FC:FeatureAssociationKey" name="FBindSuperTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureAssociations/S100FC:S100_FC_FeatureAssociation"/>
+      <xs:field xpath="S100FC:superType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:InformationAssociationKey" name="IBindSuperTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_InformationAssociations/S100FC:S100_FC_InformationAssociation"/>
+      <xs:field xpath="S100FC:superType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:FeatureAssociationKey" name="FBindSubTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureAssociations/S100FC:S100_FC_FeatureAssociation"/>
+      <xs:field xpath="S100FC:subType"/>
+    </xs:keyref>
+    <xs:keyref refer="S100FC:InformationAssociationKey" name="IBindSubTypeRef">
+      <xs:selector xpath="./S100FC:S100_FC_InformationAssociations/S100FC:S100_FC_InformationAssociation"/>
+      <xs:field xpath="S100FC:subType"/>
+    </xs:keyref>
+
+    <!-- uniqueness constraints for names (case sensitive) -->
+
+    <!-- uniqueness constraints for names of attributes -->
+    <xs:unique name="AttributeNameUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_SimpleAttributes/S100FC:S100_FC_SimpleAttribute | ./S100FC:S100_FC_ComplexAttributes/S100FC:S100_FC_ComplexAttribute"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+    <!-- uniqueness constraint for roles -->
+    <xs:unique name="RoleNameUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_Roles/S100FC:S100_FC_Role"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+    <!-- uniqueness constraint for information associations -->
+    <xs:unique name="InformationAssociationUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_InformationAssociations/S100FC:S100_FC_InformationAssociation"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+    <!-- uniqueness constraint for feature associations -->
+    <xs:unique name="FeatureAssociationUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureAssociations/S100FC:S100_FC_FeatureAssociation"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+    <!-- uniqueness constraint for information types -->
+    <xs:unique name="InformationTypeUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_InformationTypes/S100FC:S100_FC_InformationType"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+    <!-- uniqueness constraint for feature types -->
+    <xs:unique name="FeatureTypeUniqueness">
+      <xs:selector xpath="./S100FC:S100_FC_FeatureTypes/S100FC:S100_FC_FeatureType"/>
+      <xs:field xpath="S100FC:name"/>
+    </xs:unique>
+
+  </xs:element>
+  <!-- Catalog -->
+
+</xs:schema>

--- a/1.2.0/GML_schema/S129_1_2_0.xsd
+++ b/1.2.0/GML_schema/S129_1_2_0.xsd
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:S100="http://www.iho.int/s100gml/5.0"
+	xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.iho.int/S129/gml/cs0/1.0"
+	targetNamespace="http://www.iho.int/S129/gml/cs0/1.0" elementFormDefault="unqualified"
+	version="1.2.0">
+	<!--
+=============================================================================================================
+S100 XML/GML Schema for S-129 (S-129 Under Keel Clearance Management Information Product Specification).                   
+=============================================================================================================
+
+Draft Copyright, license, and disclaimer
+© Copyright 2018 ... (Formal Copyright and disclaimer statements to be supplied by IHO)
+© Copyright 2018 IHB
+
+THIS IS A DRAFT AND NO WARRANTIES ARE GIVEN TO ACCURACY OR FUNCTION OF THIS DOCUMENT
+
+Document history
+Draft 1.0.0	20200924 Draft based on S-129 UML as is in PS v1.0 (current uploaded on IHO S100 page, March, 2019).
+Draft 1.1.0	20231117 Draft based on S-129 UML as is in PS v1.1 (current uploaded on IHO GI Registry, November, 2023).
+===============================================================================================================
+-->
+
+	<!-- To do: Schematron validation rules; -->
+	<!-- profile: xmlns:gml="http://www.iho.int/S-100/profile/s100_gmlProfile"
+        deployment:
+        (1) change gml namespace to official GML namespace http://www.opengis.net/gml/3.2
+        (2) add profile namespace xmlns:s100="http://www.iho.int/S-100/profile/s100_gmlProfile"
+        (3) update import statement below correspondingly -->
+
+	<xs:import namespace="http://www.iho.int/s100gml/5.0"
+		schemaLocation="https://schemas.s100dev.net/schemas/S100/5.0.0/S100GML/20220620/s100gmlbase.xsd"/>
+	<xs:import namespace="http://www.opengis.net/gml/3.2"
+		schemaLocation="https://schemas.s100dev.net/schemas/S100/5.0.0/S100GML/20220620/S100_gmlProfile.xsd"/>
+
+	<!-- ============= -->
+	<!-- common types  -->
+	<!-- ============= -->
+
+	<!-- none included in this version since it seems the schema can be created with built-in types -->
+
+	<!-- ===================================== -->
+	<!-- spatial property convenience types    -->
+	<!-- ===================================== -->
+
+	<xs:complexType name="GM_Point">
+		<xs:choice>
+			<xs:element ref="S100:pointProperty"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="GM_Curve">
+		<!-- likely not needed -->
+		<xs:choice>
+			<xs:element ref="S100:curveProperty"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="GM_Surface">
+		<xs:choice>
+			<xs:element ref="S100:surfaceProperty"/>
+		</xs:choice>
+	</xs:complexType>
+
+	<!-- ============================ -->
+	<!-- complex attributes           -->
+	<!-- ============================ -->
+
+	<xs:complexType name="fixedTimeRangeType">
+		<xs:annotation>
+			<xs:documentation>Time interval</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="timeStart" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="timeEnd" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!-- ========================================= -->
+	<!--   enumeration types           			   -->
+	<!-- ========================================= -->
+
+	<xs:simpleType name="underKeelClearancePurposeType">
+		<xs:annotation>
+			<xs:documentation>The relevant phase of a UKC passage plan</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="prePlan">
+				<xs:annotation>
+					<xs:documentation>An indicative UKC plan that identifies potential sailing windows for a nominated vessel draught, days, weeks or months prior to the planned passage through the UKCM region.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="actualPlan">
+				<xs:annotation>
+					<xs:documentation>A detailed UKC plan that identifies sailing windows and no-go areas, integrating live weather data, hours or days prior to transiting the UKCM region.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="actualUpdate'">
+				<xs:annotation>
+					<xs:documentation>A near real-time, detailed, UKC plan that identifies sailing windows and no-go areas, using live weather, vessel position and traffic data, while the vessel is transiting the UKCM region.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="underKeelClearanceCalculationRequestedType">
+		<xs:annotation>
+			<xs:documentation>Indication of the aim of the UKC plan: to find the maximum safe vessel draught for transiting the UKCM region, or to find sailing windows for a nominated vessel draught</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="time window">
+				<xs:annotation>
+					<xs:documentation>The available wim window(s) for a given draught.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="max draught">
+				<xs:annotation>
+					<xs:documentation>The maximum draught for a given time window.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<!-- ========================================= -->
+	<!--   				feature types              -->
+	<!-- ========================================= -->
+
+	<xs:element name="FeatureType" type="FeatureType" abstract="true"
+		substitutionGroup="gml:AbstractFeature"/>
+	<xs:complexType name="FeatureType" abstract="true">
+		<xs:annotation>
+			<xs:documentation>Generalized feature type which carries all the common attributes</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="S100:AbstractFeatureType"/>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="UnderKeelClearancePlan" type="UnderKeelClearancePlanType"
+		substitutionGroup="FeatureType"/>
+	<xs:complexType name="UnderKeelClearancePlanType">
+		<xs:annotation>
+			<xs:documentation>A UKC plan calculated for a particular vessel, for a particular passage.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="FeatureType">
+				<xs:sequence>
+					<xs:element name="fixedTimeRange" type="fixedTimeRangeType" minOccurs="1"
+						maxOccurs="1"/>
+					<xs:element name="generationTime" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="vesselID" type="xs:string" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="sourceRouteName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="sourceRouteVersion" type="xs:int" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="maximumDraught" type="xs:float" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="underKeelClearancePurpose"
+						type="underKeelClearancePurposeType" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="underKeelClearanceCalculationRequested"
+						type="underKeelClearanceCalculationRequestedType" minOccurs="1"
+						maxOccurs="1"/>
+					<xs:element name="geometry" type="GM_Surface" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="consistOf" type="gml:ReferenceType" minOccurs="1"
+						maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="UnderKeelClearanceNonNavigableArea"
+		type="UnderKeelClearanceNonNavigableAreaType" substitutionGroup="FeatureType"/>
+	<xs:complexType name="UnderKeelClearanceNonNavigableAreaType">
+		<xs:annotation>
+			<xs:documentation>Anarea of depth less than the calculated safe limit.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="FeatureType">
+				<xs:sequence>
+					<xs:element name="scaleMinimum" type="xs:int" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="geometry" type="GM_Surface" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="componentOf" type="gml:ReferenceType" minOccurs="0"
+						maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="UnderKeelClearanceAlmostNonNavigableArea"
+		type="UnderKeelClearanceAlmostNonNavigableAreaType" substitutionGroup="FeatureType"/>
+	<xs:complexType name="UnderKeelClearanceAlmostNonNavigableAreaType">
+		<xs:annotation>
+			<xs:documentation>An area of depth almost less than the valculated safe limit, as established for the waterway.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="FeatureType">
+				<xs:sequence>
+					<xs:element name="distanceAboveUKCLimit" type="xs:float" minOccurs="1"
+						maxOccurs="1"/>
+					<xs:element name="scaleMinimum" type="xs:int" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="geometry" type="GM_Surface" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="componentOf" type="gml:ReferenceType" minOccurs="0"
+						maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:element name="UnderKeelClearanceControlPoint" type="UnderKeelClearanceControlPointType"
+		substitutionGroup="FeatureType"/>
+	<xs:complexType name="UnderKeelClearanceControlPointType">
+		<xs:annotation>
+			<xs:documentation>Selected critical passage point or line</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="FeatureType">
+				<xs:sequence>
+					<xs:element name="distanceAboveUKCLimit" type="xs:float" minOccurs="0"
+						maxOccurs="1"/>
+					<xs:element name="expectedPassingSpeed" type="xs:float" minOccurs="0"
+						maxOccurs="1"/>
+					<xs:element name="expectedPassingTime" type="xs:dateTime" minOccurs="0"
+						maxOccurs="1"/>
+					<xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="fixedTimeRange" type="fixedTimeRangeType" minOccurs="0"
+						maxOccurs="1"/>
+					<xs:element name="geometry" type="GM_Point" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="componentOf" type="gml:ReferenceType" minOccurs="1"
+						maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<!-- ==================================================== -->
+	<!-- 				cartographic features				  -->
+	<!-- ==================================================== -->
+
+	<!-- none in the specification -->
+
+	<!-- ========================================= -->
+	<!--    		   information types           -->
+	<!-- ========================================= -->
+
+	<xs:element name="InformationType" type="InformationType" abstract="true"
+		substitutionGroup="gml:AbstractGML"/>
+	<xs:complexType name="InformationType" abstract="true">
+		<xs:annotation>
+			<xs:documentation>Generalized information type which carry all the common attributes</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="S100:AbstractInformationType"/>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<!-- none in the specification, abstract type retained for dataset structure -->
+
+	<!-- ============================================= -->
+	<!-- 				codelists					   -->
+	<!-- ============================================= -->
+
+	<!-- none in the specification -->
+
+	<!-- ============================================= -->
+	<!-- types and elements for the dataset definition -->
+	<!-- ============================================= -->
+	<xs:complexType name="DatasetType">
+		<xs:annotation>
+			<xs:documentation>Dataset element for dataset as "GML document"</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gml:AbstractFeatureType">
+				<xs:sequence>
+					<xs:element name="DatasetIdentificationInformation"
+						type="S100:DataSetIdentificationType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Dataset identification information</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:group ref="S100:Geometry" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>Allows spatial objects to be located outside feature objects (for references, and compatibility with ISO 8211 encoding)</xs:documentation>
+						</xs:annotation>
+					</xs:group>
+					<xs:choice minOccurs="0" maxOccurs="unbounded">
+						<xs:element name="imember" minOccurs="0" maxOccurs="unbounded"
+							type="IMemberType">
+							<xs:annotation>
+								<xs:documentation>intended for S100 information types. Extension of GML practice, not addressed by ISO 19136.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="member" minOccurs="0" maxOccurs="unbounded"
+							type="MemberType">
+							<xs:annotation>
+								<xs:documentation>intended for technical GML 3.2 requirement for making the dataset a "GML document" and clause 21.3 of the OGC GML standard</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<!-- treatment of S-100 Information types is provisional, because GML does not have the concept, and they must be modeled as AbstractGML -->
+	<xs:complexType name="MemberType">
+		<xs:annotation>
+			<xs:documentation>dataset member</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gml:AbstractFeatureMemberType">
+				<xs:sequence>
+					<xs:element ref="gml:AbstractFeature"/>
+				</xs:sequence>
+				<xs:attributeGroup ref="gml:AssociationAttributeGroup"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="IMemberType">
+		<xs:annotation>
+			<xs:documentation>dataset member S-100 infotmation types</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="gml:AbstractFeatureMemberType">
+				<xs:sequence>
+					<xs:element ref="InformationType"/>
+				</xs:sequence>
+				<xs:attributeGroup ref="gml:AssociationAttributeGroup"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericFeatureType">
+		<xs:complexContent>
+			<xs:extension base="S100:AbstractFeatureType">
+				<xs:sequence>
+					<xs:any namespace="##local" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DataSet" type="DatasetType"/>
+</xs:schema>


### PR DESCRIPTION
You can check difference this site: https://www.diffchecker.com/rLLIBP8Q/

Summury of the difference in the following list:
1. uptdate metadata such as versionNumber, versionDate, etc.
2. update definition of simple attributes (come from description of PS document).
3. correct misspeelled feature name: Scale Minimum
4. update uom that Maximum Draught / Expected Passing Speed / Distance Above UKC Limit
	- it needs to discuss about adding uom and constraint
	- uom and constraint update example (from S-101)
			<S100FC:S100_FC_SimpleAttribute>
			<S100FC:name>Depth Range Maximum Value</S100FC:name>
			<S100FC:definition>The maximum (deepest) value of a depth range.</S100FC:definition>
			<S100FC:code>depthRangeMaximumValue</S100FC:code>
			<S100FC:remarks>Where the area dries, the value is negative or zero (0).</S100FC:remarks>
			<S100FC:alias>DRVAL2</S100FC:alias>
			<S100FC:definitionReference>
				<S100FC:sourceIdentifier>821</S100FC:sourceIdentifier>
				<S100FC:definitionSource ref="IHOREG" />
			</S100FC:definitionReference>
			<S100FC:valueType>real</S100FC:valueType>
			<S100FC:uom>
				<S100Base:name>metre</S100Base:name>
				<S100Base:symbol>m</S100Base:symbol>
			</S100FC:uom>
			<S100FC:quantitySpecification>otherQuantity</S100FC:quantitySpecification>
			<S100FC:constraints>
				<S100CD:textPattern>sxxxxx.xx; s = sign, negative values only</S100CD:textPattern>
				<S100CD:range>
					<S100Base:lowerBound>-30</S100Base:lowerBound>
					<S100Base:upperBound>12500</S100Base:upperBound>
					<S100Base:closure>openInterval</S100Base:closure>
				</S100CD:range>
			</S100FC:constraints>
			
5. comparision with S100FC, S100CI, S100CD schema documenation (using diffchecker).
6. XSD update (version number change, no change)