### PR TITLE
18 additional areasymbol fill for better visibility of underkeelclearancenonnavigablearea and underkeelclearancenonalmostnavigablearea in night mode

### DIFF
--- a/1.3.0/PC/S129_1_2_0_PC/Rules/main.xsl
+++ b/1.3.0/PC/S129_1_2_0_PC/Rules/main.xsl
@@ -10,7 +10,6 @@
   <xsl:include href="InformationBox.xsl"/>
 
   <xsl:param name="PlainBoundaries"/>
-  <xsl:param name="NonNavigableAreaPattern">true</xsl:param>
 
   <xsl:template match="/">
     <p:displayList xmlns:p="http://www.iho.int/S100Presentation/5.2">

--- a/1.3.0/PC/S129_1_2_0_PC/Rules/templates/symbolFillTemplate.xsl
+++ b/1.3.0/PC/S129_1_2_0_PC/Rules/templates/symbolFillTemplate.xsl
@@ -35,6 +35,7 @@
             <xsl:value-of select="$drawingPriority"/>
           </xsl:element>
           <xsl:element name="symbolFill">
+			<xsl:element name="areaCRS">GlobalGeometry</xsl:element>
             <xsl:element name="symbol">
               <xsl:attribute name="reference">
                 <xsl:value-of select="$symbolReference"/>

--- a/1.3.0/PC/S129_1_2_0_PC/portrayal_catalogue.xml
+++ b/1.3.0/PC/S129_1_2_0_PC/portrayal_catalogue.xml
@@ -172,7 +172,7 @@
     <!--********** END Viewing groups for Independent Mariner Selectors **********-->    
   </viewingGroups>
 
-  <foundationMode></foundationMode>
+  <foundationMode/>
 
   <viewingGroupLayers>
     <viewingGroupLayer id="UKCViewingGroupLayer">


### PR DESCRIPTION
Bluemap / @gorogara's clean-ups and corrections to PC after adding DIAMOND1P symbol fill portrayal for UnderKeelClearanceNonNavigableArea in night mode.